### PR TITLE
fix pandas column width setting

### DIFF
--- a/python/curriculum_teaching_frequency.py
+++ b/python/curriculum_teaching_frequency.py
@@ -11,7 +11,8 @@ matplotlib.use('agg')
 import matplotlib.pyplot as plt
 # %matplotlib inline # only for Jupyter Notebook
 
-pd.set_option('display.max_colwidth', -1)
+# Keeps long text in columns from getting truncated
+pd.set_option('display.max_colwidth', None)
 
 import numpy as np
 

--- a/python/instructor_training_seat_usage.py
+++ b/python/instructor_training_seat_usage.py
@@ -16,7 +16,7 @@ import matplotlib.pyplot as plt
 import plotly.graph_objects as go
 
 # Keeps long text in columns from getting truncated
-pd.set_option('display.max_colwidth', -1)
+pd.set_option('display.max_colwidth', None)
 
 api_key = os.environ['REDASH_KEY_QUERY187']
 


### PR DESCRIPTION
Fixes `pd.set_option('display.max_colwidth', -1)` warning mentioned in #38 