### PR TITLE
remove creation of html page

### DIFF
--- a/python/instructor_training_completion_rates.py
+++ b/python/instructor_training_completion_rates.py
@@ -75,14 +75,3 @@ plt.savefig('plot_checkout_completion_rates.svg')
 
 # Save dataframe to json
 completion_rates.to_json('checkout_completion_rates.json')
-
-crt = completion_rates.to_html()
-
-with open('checkout_completion_rates.html', 'w') as f:
-    f.write("Of all trainees who completed our two day Instructor Training course, the number of people ")
-    f.write("who completed 0, 1, or 2 checkout steps, and who completed all three steps (and were badged as Instructors.)")
-    f.write("<br>")
-    f.write("<a href='checkout_completion_rates.json'>Raw JSON data</a>")
-    f.write("<img src='plot_checkout_completion_rates.svg' />")
-
-    f.write(crt)


### PR DESCRIPTION
This file creates json data output and a bar plot showing instructor training completion rates.  It also included code to try to make a friendly web page that put the plot and its raw data on one page with some explanatory text.  The point of feeds.carpentries.org is to offer plain data feeds and images for plots so I am removing this block of code.